### PR TITLE
Fix seek method and rework event callbacks on Interpol & Timeline

### DIFF
--- a/.changeset/green-dancers-burn.md
+++ b/.changeset/green-dancers-burn.md
@@ -1,0 +1,80 @@
+---
+"@wbe/interpol": minor
+---
+
+Fix seek method and rework event callbacks on Interpol & Timeline
+
+This PR reveal allows Timeline `onComplete()`exec when using `tl.seek()` method. A major bug has been discovered about the seek method who wasn't working as expected, and is fixed in this PR too.
+
+## event callbacks
+
+before:
+
+```ts
+const tl: Timeline = new Timeline({
+  paused: true,
+  // wasn't called with seek method
+  onComplete: () => console.log(`tl onComplete!`),
+})
+
+tl.seek(1)
+```
+
+after:
+
+```ts
+const tl: Timeline = new Timeline({
+  paused: true,
+  // Is executed on seek(1) is suppressTlEvents is false
+  onComplete: () => console.log(`tl onComplete!`)
+})
+
+tl.seek(0, true, false)
+tl.seek(1, true, false) 
+```
+
+## Timeline suppressEvents & suppressTlEvents
+
+`Timeline.seek()` method takes two new arguments: `suppressEvents` & `suppressTlEvents`
+
+```ts
+  public seek(progress: number, suppressEvents = true, suppressTlEvents = true): void
+```
+
+- only execute the timeline event callbacks:
+
+```ts
+tl.seek(0.5, true, false)
+```
+
+- only execute "Timeline adds" `onComplete` callbacks :
+
+```ts
+tl.seek(0.5, false, true)
+```
+
+`suppressEvents` params as been copied from gsap API. On the other hand, `suppressTlEvents` doesn't exist in GSAP.
+
+Example of **Timeline**: with `suppressEvents = false` and `suppressTlEvents = false` we have the same behavior on play/reverse and on seek:
+https://github.com/willybrauner/interpol/assets/7604357/414cb316-cf69-4d24-bcba-5ec267427efa
+
+## Interpol suppressEvents
+
+In the same way, Interpol `suppressEvents` is available (default: true)
+
+```ts
+  public seek(progress: number, suppressEvents = true): void
+```
+
+Example of **Interpol**: with `suppressEvents = false` we have the same behavior on play/reverse on seek:
+https://github.com/willybrauner/interpol/assets/7604357/96601416-2679-46ea-b918-dfd4559bc7c7
+
+## Callback executions logic
+
+- in Interpol and In Timeline, `onComplete` is called only on play and seek(1)
+- `onReverseComplete` should be create for the reverse purpose
+
+## TODO in other PRs
+
+- create `onReverseComplete`
+- exec beforeStart() too

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ itp.stop()
 itp.refreshComputedValues()
 
 // Seek to a specific time
-// seek(progress: number): void
+// seek(progress: number, suppressEvents = true): void
 // progress: number between 0 and 1
 itp.seek(progress)
 ```
@@ -436,7 +436,7 @@ tl.resume()
 tl.stop()
 
 // seek to a specific time
-// seek(progress: number): void
+// seek(progress: number, suppressEvents = true, suppressTlEvents = true): void
 // progress is a number between 0 and 1
 tl.seek(progress)
 ```

--- a/README.md
+++ b/README.md
@@ -216,11 +216,7 @@ const element = document.querySelector("div")
 // Create a timeline instance
 const tl = new Timeline({ 
   paused: true,
-  onComplete: () => {
-    tl.isReversed() 
-      ? console.log("Timeline reverse is complete") 
-      : console.log("Timeline is complete")
-  },
+  onComplete: () => console.log("Timeline is complete")
 })
 
 // `add()` can recieve an Interpol object constructor
@@ -252,7 +248,7 @@ tl.add({
   "-=100")
 
 await tl.play()
-// timeline is complete
+// timeline is complete, start reverse
 await tl.reverse()
 // timeline reverse is complete
 ```

--- a/examples/interpol-basic/index.html
+++ b/examples/interpol-basic/index.html
@@ -16,6 +16,9 @@
           <button class="resume">resume</button>
           <button class="stop">stop</button>
           <button class="refresh">refresh</button>
+          <button class="seek-0">seek 0</button>
+          <button class="seek-05">seek .5</button>
+          <button class="seek-1">seek 1</button>
           <input class="progress" value="0" type="number"/>
         </div>
         <div class="wrapper">

--- a/examples/interpol-basic/index.html
+++ b/examples/interpol-basic/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
@@ -19,13 +19,13 @@
           <button class="seek-0">seek 0</button>
           <button class="seek-05">seek .5</button>
           <button class="seek-1">seek 1</button>
-          <input class="progress" value="0" type="number"/>
+          <input class="progress" value="0" type="number" />
+          <input class="slider" type="range" min="0" max="100" value="0" />
         </div>
         <div class="wrapper">
           <div class="ball"></div>
         </div>
       </div>
-    </div>
     </div>
     <script type="module" src="src/main.ts"></script>
   </body>

--- a/examples/interpol-basic/src/main.ts
+++ b/examples/interpol-basic/src/main.ts
@@ -6,8 +6,11 @@ import { InterpolOptions } from "@wbe/interpol"
     (document.querySelector<HTMLButtonElement>(`.${name}`)!.onclick = () => {
       // @ts-ignore
       itp[name]()
-    })
+    }),
 )
+document.querySelector<HTMLButtonElement>(`.seek-0`)!.onclick = () => itp.seek(0, false)
+document.querySelector<HTMLButtonElement>(`.seek-05`)!.onclick = () => itp.seek(0.5, false)
+document.querySelector<HTMLButtonElement>(`.seek-1`)!.onclick = () => itp.seek(1, false)
 
 const inputProgress = document.querySelector<HTMLInputElement>(".progress")
 
@@ -27,14 +30,14 @@ const itp = new Interpol({
     y: [0, 300],
   },
   duration: 1000,
-  ease: "power3.out",
+  ease: "linear",
   onUpdate: ({ x, y }) => {
     $el!.style.transform = `translate3d(${x}px, ${y}px, 0px)`
   },
 })
 
-console.log(itp)
-console.log(InterpolOptions.ticker)
+console.log("itp", itp)
+console.log("InterpolOptions.ticker", InterpolOptions.ticker)
 InterpolOptions.ticker.disable()
 
 const tick = (e: number) => {

--- a/examples/interpol-basic/src/main.ts
+++ b/examples/interpol-basic/src/main.ts
@@ -1,6 +1,22 @@
 import { Interpol } from "@wbe/interpol"
 import "./index.less"
 import { InterpolOptions } from "@wbe/interpol"
+
+/**
+ * Query
+ */
+const ball = document.querySelector<HTMLElement>(".ball")
+
+const seek0 = document.querySelector<HTMLButtonElement>(".seek-0")
+const seek05 = document.querySelector<HTMLButtonElement>(".seek-05")
+const seek1 = document.querySelector<HTMLButtonElement>(".seek-1")
+
+const inputProgress = document.querySelector<HTMLInputElement>(".progress")
+const inputSlider = document.querySelector<HTMLInputElement>(".slider")
+
+/**
+ * Events
+ */
 ;["play", "reverse", "pause", "stop", "refresh", "resume"].forEach(
   (name: any) =>
     (document.querySelector<HTMLButtonElement>(`.${name}`)!.onclick = () => {
@@ -8,31 +24,23 @@ import { InterpolOptions } from "@wbe/interpol"
       itp[name]()
     }),
 )
-document.querySelector<HTMLButtonElement>(`.seek-0`)!.onclick = () => itp.seek(0, false)
-document.querySelector<HTMLButtonElement>(`.seek-05`)!.onclick = () => itp.seek(0.5, false)
-document.querySelector<HTMLButtonElement>(`.seek-1`)!.onclick = () => itp.seek(1, false)
 
-const inputProgress = document.querySelector<HTMLInputElement>(".progress")
+seek0!.onclick = () => itp.seek(0, false)
+seek05!.onclick = () => itp.seek(0.5, false)
+seek1!.onclick = () => itp.seek(1, false)
 
-if (inputProgress) {
-  inputProgress.onchange = () => {
-    console.log("e", parseFloat(inputProgress.value) / 100)
-    itp.seek(parseFloat(inputProgress.value) / 100)
-  }
-}
-
-const $el = document.querySelector<HTMLElement>(".ball")
+inputProgress!.onchange = () => itp.seek(parseFloat(inputProgress!.value) / 100, false)
+inputSlider!.oninput = () => itp.seek(parseFloat(inputSlider!.value) / 100, false)
 
 const itp = new Interpol({
-  debug: true,
+  // debug: true,
+  el: ball,
   props: {
-    x: [0, 300],
-    y: [0, 300],
+    x: [0, 300, "px"],
+    y: [0, 300, "px"],
   },
-  duration: 1000,
-  ease: "linear",
-  onUpdate: ({ x, y }) => {
-    $el!.style.transform = `translate3d(${x}px, ${y}px, 0px)`
+  onComplete: (props, time, progress) => {
+    console.log("itp onComplete")
   },
 })
 

--- a/examples/interpol-timeline/index.html
+++ b/examples/interpol-timeline/index.html
@@ -10,15 +10,15 @@
     <div id="root">
       <div class="App">
         <div class="Controls">
-          <button class="seek-0">seek 0</button>
-          <button class="seek-05">seek .5</button>
-          <button class="seek-1">seek 1</button>
           <button class="play">play</button>
           <button class="reverse">reverse</button>
           <button class="pause">pause</button>
           <button class="resume">resume</button>
           <button class="stop">stop</button>
           <button class="refresh">refresh</button>
+          <button class="seek-0">seek 0</button>
+          <button class="seek-05">seek .5</button>
+          <button class="seek-1">seek 1</button>
           <input class="progress" value="0" type="number"/>
           <input class="slider" type="range" min="0" max="100" value="0">
 

--- a/examples/interpol-timeline/index.html
+++ b/examples/interpol-timeline/index.html
@@ -10,6 +10,9 @@
     <div id="root">
       <div class="App">
         <div class="Controls">
+          <button class="seek-0">seek 0</button>
+          <button class="seek-05">seek .5</button>
+          <button class="seek-1">seek 1</button>
           <button class="play">play</button>
           <button class="reverse">reverse</button>
           <button class="pause">pause</button>

--- a/examples/interpol-timeline/src/main.ts
+++ b/examples/interpol-timeline/src/main.ts
@@ -5,9 +5,9 @@ import "./index.less"
 ;["play", "reverse", "pause", "stop", "refresh", "resume"].forEach(
   (name) => (document.querySelector<HTMLButtonElement>(`.${name}`).onclick = () => tl[name]()),
 )
-document.querySelector<HTMLButtonElement>(`.seek-0`).onclick = () => tl.seek(0)
-document.querySelector<HTMLButtonElement>(`.seek-05`).onclick = () => tl.seek(0.5, false)
-document.querySelector<HTMLButtonElement>(`.seek-1`).onclick = () => tl.seek(1, false)
+document.querySelector<HTMLButtonElement>(`.seek-0`).onclick = () => tl.seek(0, false, false)
+document.querySelector<HTMLButtonElement>(`.seek-05`).onclick = () => tl.seek(0.5, false, false)
+document.querySelector<HTMLButtonElement>(`.seek-1`).onclick = () => tl.seek(1, false, false)
 
 const inputProgress = document.querySelector<HTMLInputElement>(".progress")
 inputProgress.onchange = () => {

--- a/examples/interpol-timeline/src/main.ts
+++ b/examples/interpol-timeline/src/main.ts
@@ -1,7 +1,7 @@
 import { Power1, Timeline, Interpol } from "@wbe/interpol"
 import "./index.less"
 ;["play", "reverse", "pause", "stop", "refresh", "resume"].forEach(
-  (name) => (document.querySelector<HTMLButtonElement>(`.${name}`).onclick = () => tl[name]())
+  (name) => (document.querySelector<HTMLButtonElement>(`.${name}`).onclick = () => tl[name]()),
 )
 
 const inputProgress = document.querySelector<HTMLInputElement>(".progress")
@@ -37,7 +37,7 @@ const duration = 1000
 const tl: Timeline = new Timeline({
   debug: true,
   paused: true,
-  onComplete: () => console.log(`tl complete reverse ? ${tl.isReversed}`),
+  onComplete: () => console.log(`tl onComplete!`),
 })
 
 const itp = new Interpol<"y" | "x">({
@@ -92,4 +92,10 @@ tl.add({
   onComplete: (e) => {
     console.log("itp 3 onComplete", e)
   },
+})
+
+// TODO all Tl adds are not updated properly to the last frame
+window.addEventListener("resize", () => {
+  console.log("resize")
+  tl.seek(1)
 })

--- a/examples/interpol-timeline/src/main.ts
+++ b/examples/interpol-timeline/src/main.ts
@@ -1,106 +1,76 @@
 import { Power1, Timeline, Interpol } from "@wbe/interpol"
+import { styles } from "@wbe/interpol"
 import "./index.less"
 
-//
-;["play", "reverse", "pause", "stop", "refresh", "resume"].forEach(
-  (name) => (document.querySelector<HTMLButtonElement>(`.${name}`).onclick = () => tl[name]()),
-)
-document.querySelector<HTMLButtonElement>(`.seek-0`).onclick = () => tl.seek(0, false, false)
-document.querySelector<HTMLButtonElement>(`.seek-05`).onclick = () => tl.seek(0.5, false, false)
-document.querySelector<HTMLButtonElement>(`.seek-1`).onclick = () => tl.seek(1, false, false)
-
-const inputProgress = document.querySelector<HTMLInputElement>(".progress")
-inputProgress.onchange = () => {
-  tl.seek(parseFloat(inputProgress.value) / 100)
-}
-const inputSlider = document.querySelector<HTMLInputElement>(".slider")
-inputSlider.oninput = () => {
-  tl.seek(parseFloat(inputSlider.value) / 100)
-}
-document.querySelector<HTMLButtonElement>(`.play`).onclick = () => tl.play()
-document.querySelector<HTMLButtonElement>(`.reverse`).onclick = () => tl.reverse()
+/**
+ * Query
+ */
 const ball = document.querySelector<HTMLElement>(".ball")
 const ball2 = document.querySelector<HTMLElement>(".ball-2")
 
-/**
- * Utils
- *
- *
- *
- */
-const styles = (el: HTMLElement | null, s: Record<string, string>) => {
-  for (let key in s) if (s.hasOwnProperty(key)) el.style[key] = s[key]
-}
+const seek0 = document.querySelector<HTMLButtonElement>(".seek-0")
+const seek05 = document.querySelector<HTMLButtonElement>(".seek-05")
+const seek1 = document.querySelector<HTMLButtonElement>(".seek-1")
+
+const inputProgress = document.querySelector<HTMLInputElement>(".progress")
+const inputSlider = document.querySelector<HTMLInputElement>(".slider")
 
 /**
- *
- * Example
- *
- *
+ * Events
  */
-const duration = 1000
+;["play", "reverse", "pause", "stop", "refresh", "resume"].forEach(
+  (name) => (document.querySelector<HTMLButtonElement>(`.${name}`).onclick = () => tl[name]()),
+)
+seek0.onclick = () => tl.seek(0, false, false)
+seek05.onclick = () => tl.seek(0.5, false, false)
+seek1.onclick = () => tl.seek(1, false, false)
+
+inputProgress.onchange = () => tl.seek(parseFloat(inputProgress.value) / 100, false, false)
+inputSlider.oninput = () => tl.seek(parseFloat(inputSlider.value) / 100, false, false)
+
+window.addEventListener("resize", () => tl.seek(1))
+
+/**
+ * Timeline
+ */
 const tl: Timeline = new Timeline({
   debug: true,
-  paused: true,
-  onComplete: () => console.log(`tl onComplete!`),
+  onComplete: (time, progress) => console.log(`tl onComplete!`),
 })
 
-const itp = new Interpol<"y" | "x">({
+const itp = new Interpol({
+  el: ball,
   props: {
-    x: [0, 200],
-    y: [0, 200],
+    x: [0, 200, "px"],
+    y: [0, 200, "px"],
   },
-  duration,
   ease: Power1.in,
-  onUpdate: ({ x, y }) => {
-    styles(ball, {
-      transform: `translate3d(${x}px, ${y}px, 0)`,
-    })
-  },
-
   onComplete: (e) => {
     console.log("itp 1 onComplete", e)
   },
 })
-
 tl.add(itp)
 
 tl.add({
+  el: ball,
   props: {
-    x: [200, 100],
-    y: [200, 300],
+    x: [200, 100, "px"],
+    y: [200, 300, "px"],
   },
-  duration,
   ease: Power1.out,
-  onUpdate: ({ x, y }) => {
-    styles(ball, {
-      transform: `translate3d(${x}px, ${y}px, 0)`,
-    })
-  },
   onComplete: (e) => {
     console.log("itp 2 onComplete", e)
   },
 })
 
 tl.add({
+  el: ball2,
   props: {
-    x: [0, 100],
-    y: [0, 400],
+    x: [0, 100, "px"],
+    y: [0, 400, "px"],
   },
-  duration,
   ease: Power1.out,
-  onUpdate: ({ x, y }) => {
-    styles(ball2, {
-      transform: `translate3d(${x}px, ${y}px, 0)`,
-    })
-  },
   onComplete: (e) => {
     console.log("itp 3 onComplete", e)
   },
-})
-
-// TODO all Tl adds are not updated properly to the last frame
-window.addEventListener("resize", () => {
-  console.log("resize")
-  tl.seek(1)
 })

--- a/examples/interpol-timeline/src/main.ts
+++ b/examples/interpol-timeline/src/main.ts
@@ -1,8 +1,13 @@
 import { Power1, Timeline, Interpol } from "@wbe/interpol"
 import "./index.less"
+
+//
 ;["play", "reverse", "pause", "stop", "refresh", "resume"].forEach(
   (name) => (document.querySelector<HTMLButtonElement>(`.${name}`).onclick = () => tl[name]()),
 )
+document.querySelector<HTMLButtonElement>(`.seek-0`).onclick = () => tl.seek(0)
+document.querySelector<HTMLButtonElement>(`.seek-05`).onclick = () => tl.seek(0.5, false)
+document.querySelector<HTMLButtonElement>(`.seek-1`).onclick = () => tl.seek(1, false)
 
 const inputProgress = document.querySelector<HTMLInputElement>(".progress")
 inputProgress.onchange = () => {

--- a/packages/interpol/package-lock.json
+++ b/packages/interpol/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wbe/interpol",
-  "version": "0.10.0-beta.1",
+  "version": "0.10.4-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wbe/interpol",
-      "version": "0.10.0-beta.1",
+      "version": "0.10.4-beta.1",
       "dependencies": {
         "@wbe/debug": "^1.1.0"
       },

--- a/packages/interpol/package.json
+++ b/packages/interpol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wbe/interpol",
-  "version": "0.10.3",
+  "version": "0.10.4-beta.1",
   "type": "module",
   "files": [
     "dist"

--- a/packages/interpol/src/Interpol.ts
+++ b/packages/interpol/src/Interpol.ts
@@ -294,10 +294,15 @@ export class Interpol<K extends keyof Props = keyof Props> {
       p: this.#progress,
     })
 
-    // on complete
-    if ((!this.#isReversed && this.#progress === 1) || (this.#isReversed && this.#progress === 0)) {
+    // on play complete
+    if (!this.#isReversed && this.#progress === 1) {
       this.#log(`handleTick onComplete!`)
       this.#onComplete(this.#propsValueRef, this.#time, this.#progress)
+      this.#onCompleteDeferred.resolve()
+      this.stop()
+    }
+    // on reverse complete
+    if (this.#isReversed && this.#progress === 0) {
       this.#onCompleteDeferred.resolve()
       this.stop()
     }

--- a/packages/interpol/src/Interpol.ts
+++ b/packages/interpol/src/Interpol.ts
@@ -288,7 +288,7 @@ export class Interpol<K extends keyof Props = keyof Props> {
 
     // Pass value, time and progress
     this.#onUpdate(this.#propsValueRef, this.#time, this.#progress)
-    this.#log("handleTickerUpdate onUpdate", {
+    this.#log("handleTick onUpdate", {
       props: this.#propsValueRef,
       t: this.#time,
       p: this.#progress,
@@ -296,7 +296,7 @@ export class Interpol<K extends keyof Props = keyof Props> {
 
     // on complete
     if ((!this.#isReversed && this.#progress === 1) || (this.#isReversed && this.#progress === 0)) {
-      this.#log(`handleTickerUpdate onComplete!`)
+      this.#log(`handleTick onComplete!`)
       this.#onComplete(this.#propsValueRef, this.#time, this.#progress)
       this.#onCompleteDeferred.resolve()
       this.stop()

--- a/packages/interpol/src/Timeline.ts
+++ b/packages/interpol/src/Timeline.ts
@@ -215,6 +215,7 @@ export class Timeline {
     this.#progress = clamp(0, progress, 1)
     this.#time = clamp(0, this.#tlDuration * this.#progress, this.#tlDuration)
     this.#updateAdds(this.#time, this.#progress)
+    if (progress === 0 || progress === 1) this.#onComplete(this.#time, this.#progress)
   }
 
   /**

--- a/packages/interpol/src/Timeline.ts
+++ b/packages/interpol/src/Timeline.ts
@@ -46,6 +46,8 @@ export class Timeline {
   #debugEnable: boolean
   #onUpdate: (time: number, progress: number) => void
   #onComplete: (time: number, progress: number) => void
+  #lastTlProgress = 0
+  #reverseLoop = false
 
   constructor({
     onUpdate = noop,
@@ -71,7 +73,7 @@ export class Timeline {
    */
   public add<K extends keyof Props>(
     interpol: Interpol | InterpolConstruct<K>,
-    offset: number | string = "0"
+    offset: number | string = "0",
   ): Timeline {
     // Create Interpol instance or not
     const itp = interpol instanceof Interpol ? interpol : new Interpol<K>(interpol)
@@ -210,12 +212,14 @@ export class Timeline {
     this.#ticker.remove(this.#handleTick)
   }
 
-  public seek(progress: number): void {
+  public seek(progress: number, suppressEvents = true, suppressTlEvents = true): void {
     if (this.#isPlaying) this.pause()
     this.#progress = clamp(0, progress, 1)
     this.#time = clamp(0, this.#tlDuration * this.#progress, this.#tlDuration)
-    this.#updateAdds(this.#time, this.#progress)
-    if (progress === 0 || progress === 1) this.#onComplete(this.#time, this.#progress)
+    this.#updateAdds(this.#time, this.#progress, suppressEvents)
+    if ((progress === 0 || progress === 1) && !suppressTlEvents) {
+      this.#onComplete(this.#time, this.#progress)
+    }
   }
 
   /**
@@ -230,8 +234,7 @@ export class Timeline {
   #handleTick = async ({ delta }): Promise<any> => {
     this.#time = clamp(0, this.#tlDuration, this.#time + (this.#isReversed ? -delta : delta))
     this.#progress = clamp(0, round(this.#time / this.#tlDuration), 1)
-    this.#updateAdds(this.#time, this.#progress)
-
+    this.#updateAdds(this.#time, this.#progress, false)
     // prettier-ignore
     if (
       (!this.#isReversed && this.#progress === 1)
@@ -249,36 +252,37 @@ export class Timeline {
    * Main update function witch seek all adds on there relative time in TL
    * @param tlTime
    * @param tlProgress
+   * @param suppressEvents
    */
-  #updateAdds(tlTime: number, tlProgress: number): void {
+  #updateAdds(tlTime: number, tlProgress: number, suppressEvents = true): void {
+    // Determine if the Adds loop should be reversed
+    if (this.#lastTlProgress > tlProgress && !this.#reverseLoop) this.#reverseLoop = true
+    if (this.#lastTlProgress < tlProgress && this.#reverseLoop) this.#reverseLoop = false
+    this.#lastTlProgress = tlProgress
+
+    // Call constructor onUpdate
     this.#onUpdate(tlTime, tlProgress)
 
+    // Then seek all itps
     this.#onAllAdds((add) => {
-      // register last and current progress in current add
+      // Register last and current progress in current add
       add.progress.last = add.progress.current
       add.progress.current = (tlTime - add.time.start) / add.itp.duration
-
-      if (
-        // if current add is in progress range of TL progress
-        (add.progress.start <= tlProgress && add.progress.end >= tlProgress) ||
-        // OR, if we are on special case where last progress is smaller than 1 and current progress is 1 or more
-        // ex: last = 0.9 and current = 1.1 -> need to seek to exactly 1 (clamped by itp.seek)
-        (add.progress.last < 1 && Math.floor(add.progress.current) === 1) ||
-        // OR, if last progress is smaller than 0 and current progress is 0 or more
-        // ex: last = -0.01 and current = 0.05 -> need to seek exactly 0 (clamped by itp.seek)
-        (add.progress.current < 0 && Math.floor(add.progress.last) === 0)
-      ) {
-        add.itp.seek(add.progress.current)
-      }
-    })
+      add.itp.seek(add.progress.current, suppressEvents)
+    }, this.#reverseLoop)
   }
 
   /**
    * Exe Callback function on all adds
-   * @param cb
+   * Need to call from 0 to x or x to 0, depends on reversed state
+   * @param {(add: IAdd, i?: number) => void} cb
+   * @param {boolean} reverse Call from X to 0 index
    */
-  #onAllAdds(cb: (add: IAdd, i?: number) => void): void {
-    for (let i = 0; i < this.#adds.length; i++) cb(this.#adds[i], i)
+  #onAllAdds(cb: (add: IAdd, i?: number) => void, reverse = false): void {
+    const startIndex = reverse ? this.#adds.length - 1 : 0
+    const endIndex = reverse ? -1 : this.#adds.length
+    const step = reverse ? -1 : 1
+    for (let i = startIndex; i !== endIndex; i += step) cb(this.#adds[i], i)
   }
 
   /**

--- a/packages/interpol/src/Timeline.ts
+++ b/packages/interpol/src/Timeline.ts
@@ -217,7 +217,7 @@ export class Timeline {
     this.#progress = clamp(0, progress, 1)
     this.#time = clamp(0, this.#tlDuration * this.#progress, this.#tlDuration)
     this.#updateAdds(this.#time, this.#progress, suppressEvents)
-    if ((progress === 0 || progress === 1) && !suppressTlEvents) {
+    if (progress === 1 && !suppressTlEvents) {
       this.#onComplete(this.#time, this.#progress)
     }
   }
@@ -231,17 +231,19 @@ export class Timeline {
    * @param delta
    * @private
    */
+  // prettier-ignore
   #handleTick = async ({ delta }): Promise<any> => {
     this.#time = clamp(0, this.#tlDuration, this.#time + (this.#isReversed ? -delta : delta))
     this.#progress = clamp(0, round(this.#time / this.#tlDuration), 1)
     this.#updateAdds(this.#time, this.#progress, false)
-    // prettier-ignore
-    if (
-      (!this.#isReversed && this.#progress === 1)
-      || (this.#isReversed && this.#progress === 0)
-      || this.#tlDuration === 0
-    ) {
+    // on play complete
+    if ((!this.#isReversed && this.#progress === 1) || this.#tlDuration === 0) {
       this.#onComplete(this.#time, this.#progress)
+      this.#onCompleteDeferred.resolve()
+      this.stop()
+    }
+    // on reverse complete
+    if ((this.#isReversed && this.#progress === 0) || this.#tlDuration === 0) {
       this.#onCompleteDeferred.resolve()
       this.stop()
     }

--- a/packages/interpol/tests/Interpol.reverse.test.ts
+++ b/packages/interpol/tests/Interpol.reverse.test.ts
@@ -23,7 +23,7 @@ describe.concurrent("Interpol reverse", () => {
         itp.reverse()
         expect(itp.isReversed).toBe(true)
         await wait(1000)
-        expect(onComplete).toHaveBeenCalledTimes(1)
+        expect(onComplete).toHaveBeenCalledTimes(0)
         resolve()
       })
     },

--- a/packages/interpol/tests/Interpol.seek.test.ts
+++ b/packages/interpol/tests/Interpol.seek.test.ts
@@ -1,0 +1,55 @@
+import { it, expect, vi, describe } from "vitest"
+import { Interpol, Timeline } from "../src"
+import "./_setup"
+
+describe.concurrent("Interpol seek", () => {
+  it("Interpol should be seekable to specific progress", () => {
+    return new Promise(async (resolve: any) => {
+      const mock = vi.fn()
+      const itp = new Interpol({
+        props: { v: [0, 100] },
+        duration: 1000,
+        onUpdate: ({ v }) => mock(v),
+      })
+      for (let v of [0.25, 0.5, 0.75, 1]) {
+        // seek will pause the interpol, that's why the test is instant
+        itp.seek(v)
+        expect(mock).toHaveBeenCalledWith(100 * v)
+      }
+      resolve()
+    })
+  })
+
+  it("Should execute Interpol events callbacks on seek if suppressEvents is false", () => {
+    return new Promise(async (resolve: any) => {
+      const onComplete = vi.fn()
+      const itp = new Interpol({ props: { v: [0, 100] }, onComplete })
+      // onComplete is called each time the interpol reach the end (progress 1)
+      itp.seek(0.5, false)
+      expect(onComplete).toHaveBeenCalledTimes(0)
+      itp.seek(1, false) // will call onComplete
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      itp.seek(0.25, false)
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      itp.seek(1, false) // will call onComplete again
+      expect(onComplete).toHaveBeenCalledTimes(2)
+      itp.seek(0, false)
+      expect(onComplete).toHaveBeenCalledTimes(2)
+      resolve()
+    })
+  })
+
+  it("Shouldn't execute Interpol events callbacks on seek if suppressEvents is true", () => {
+    return new Promise(async (resolve: any) => {
+      const onComplete = vi.fn()
+      const itp = new Interpol({ props: { v: [0, 100] }, onComplete })
+      itp.seek(0.5)
+      itp.seek(1)
+      itp.seek(0.25)
+      itp.seek(1)
+      itp.seek(0)
+      expect(onComplete).toHaveBeenCalledTimes(0)
+      resolve()
+    })
+  })
+})

--- a/packages/interpol/tests/Timeline.callbacks.test.ts
+++ b/packages/interpol/tests/Timeline.callbacks.test.ts
@@ -1,9 +1,28 @@
 import { it, expect, vi, describe } from "vitest"
 import { Timeline } from "../src"
-import { wait } from "./utils/wait"
 import "./_setup"
 
 describe.concurrent("Timeline callbacks", () => {
+  it("Timeline should execute Timeline events callback once & on play only", () => {
+    return new Promise(async (resolve: any) => {
+      const onComplete = vi.fn()
+      const tl = new Timeline({ paused: true, onComplete })
+      tl.add({
+        props: { v: [0, 100] },
+        duration: 100,
+      })
+      tl.add({
+        props: { v: [0, 100] },
+        duration: 100,
+      })
+      await tl.play()
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      await tl.reverse()
+      expect(onComplete).toHaveBeenCalledTimes(1)
+      resolve()
+    })
+  })
+
   it("Timeline should execute interpol's onComplete once", () => {
     return new Promise(async (resolve: any) => {
       const onComplete1 = vi.fn()
@@ -19,34 +38,10 @@ describe.concurrent("Timeline callbacks", () => {
         duration: 100,
         onComplete: () => onComplete2(),
       })
-
       await tl.play()
       expect(onComplete1).toHaveBeenCalledTimes(1)
-      expect(onComplete2).toHaveBeenCalledTimes(1)
-      resolve()
-    })
-  })
-
-  it("Timeline should execute Timeline onComplete once", () => {
-    return new Promise(async (resolve: any) => {
-      const onComplete = vi.fn()
-
-      const tl = new Timeline({ paused: true, onComplete })
-      tl.add({
-        props: { v: [0, 100] },
-        duration: 100,
-      })
-      tl.add({
-        props: { v: [0, 100] },
-        duration: 100,
-      })
-
-      await tl.play()
-      expect(onComplete).toHaveBeenCalledTimes(1)
-
       await tl.reverse()
-      await wait(10)
-      expect(onComplete).toHaveBeenCalledTimes(2)
+      expect(onComplete2).toHaveBeenCalledTimes(1)
       resolve()
     })
   })

--- a/packages/interpol/tests/Timeline.reverse.test.ts
+++ b/packages/interpol/tests/Timeline.reverse.test.ts
@@ -36,7 +36,7 @@ describe.concurrent("Timeline reverse", () => {
       await tl.play()
       await tl.reverse()
 
-      expect(onCompleteMock).toBeCalledTimes(4)
+      expect(onCompleteMock).toBeCalledTimes(2)
       resolve()
     })
   })

--- a/packages/interpol/tests/Timeline.seek.test.ts
+++ b/packages/interpol/tests/Timeline.seek.test.ts
@@ -3,34 +3,92 @@ import { Timeline } from "../src"
 import "./_setup"
 
 describe.concurrent("Timeline seek", () => {
-  it("Timeline should execute interpol's onComplete on seek", () => {
+  it("Timeline should be seekable to specific tl progress", () => {
     return new Promise(async (resolve: any) => {
-      const onComplete1 = vi.fn()
-      const onComplete2 = vi.fn()
+      const mock = vi.fn()
       const tl = new Timeline({ paused: true })
       tl.add({
         props: { v: [0, 100] },
         duration: 200,
-        onComplete: () => onComplete1(),
+        onUpdate: ({ v }) => mock(v),
+      })
+      for (let v of [0.25, 0.5, 0.75, 1]) {
+        tl.seek(v)
+        expect(mock).toHaveBeenCalledWith(100 * v)
+      }
+      resolve()
+    })
+  })
+
+  it("Timeline should execute interpol's events callbacks on seek if suppressEvents is false", () => {
+    return new Promise(async (resolve: any) => {
+      const onComplete1 = vi.fn()
+      const onComplete2 = vi.fn()
+      const onTlComplete = vi.fn()
+      const tl = new Timeline({ paused: true, onComplete: onTlComplete })
+      tl.add({
+        props: { v: [0, 100] },
+        duration: 100,
+        onComplete: onComplete1,
       })
       tl.add({
         props: { v: [0, 100] },
-        duration: 200,
-        onComplete: () => onComplete2(),
+        duration: 100,
+        onComplete: onComplete2,
+      })
+
+      tl.seek(0.5, false, false)
+      expect(onComplete1).toHaveBeenCalledTimes(1)
+      expect(onComplete2).toHaveBeenCalledTimes(0)
+      tl.seek(1, false, false)
+      expect(onComplete1).toHaveBeenCalledTimes(1)
+      expect(onComplete2).toHaveBeenCalledTimes(1)
+      tl.seek(0.5, false, false)
+      expect(onComplete1).toHaveBeenCalledTimes(1)
+      expect(onComplete2).toHaveBeenCalledTimes(1)
+      tl.seek(1, false, false)
+      expect(onComplete1).toHaveBeenCalledTimes(1)
+      expect(onComplete2).toHaveBeenCalledTimes(2)
+
+      // because 3th argument suppressTlEvents is "false"
+      expect(onTlComplete).toHaveBeenCalledTimes(2)
+
+      resolve()
+    })
+  })
+
+  it("Timeline should execute interpol's events callbacks on seek if suppressEvents is true", () => {
+    return new Promise(async (resolve: any) => {
+      const onComplete1 = vi.fn()
+      const onComplete2 = vi.fn()
+      const onTlComplete = vi.fn()
+      const tl = new Timeline({ paused: true, onComplete: onTlComplete })
+      tl.add({
+        props: { v: [0, 100] },
+        duration: 100,
+        onComplete: onComplete1,
+      })
+      tl.add({
+        props: { v: [0, 100] },
+        duration: 100,
+        onComplete: onComplete2,
       })
 
       tl.seek(0.5)
-      expect(onComplete1).toHaveBeenCalledTimes(1)
+      expect(onComplete1).toHaveBeenCalledTimes(0)
       expect(onComplete2).toHaveBeenCalledTimes(0)
       tl.seek(1)
-      expect(onComplete1).toHaveBeenCalledTimes(1)
-      expect(onComplete2).toHaveBeenCalledTimes(1)
+      expect(onComplete1).toHaveBeenCalledTimes(0)
+      expect(onComplete2).toHaveBeenCalledTimes(0)
       tl.seek(0.5)
-      expect(onComplete1).toHaveBeenCalledTimes(2)
-      expect(onComplete2).toHaveBeenCalledTimes(1)
+      expect(onComplete1).toHaveBeenCalledTimes(0)
+      expect(onComplete2).toHaveBeenCalledTimes(0)
       tl.seek(1)
-      expect(onComplete1).toHaveBeenCalledTimes(2)
-      expect(onComplete2).toHaveBeenCalledTimes(2)
+      expect(onComplete1).toHaveBeenCalledTimes(0)
+      expect(onComplete2).toHaveBeenCalledTimes(0)
+
+      // because 3th argument suppressTlEvents is "true" by default
+      expect(onTlComplete).toHaveBeenCalledTimes(0)
 
       resolve()
     })


### PR DESCRIPTION
This PR reveal allows Timeline `onComplete()`exec when using `tl.seek()` method.

A major bug has been discovered about the seek method who wasn't working as expected, and fixed in this PR too. 

## event callbacks

before:
```ts
const tl: Timeline = new Timeline({
  paused: true,
  // wasn't called with seek method
  onComplete: () => console.log(`tl onComplete!`)
})

tl.seek(1)
```

after:
```ts
const tl: Timeline = new Timeline({
  paused: true,
  // Is executed on seek(1) is suppressTlEvents is false
  onComplete: () => console.log(`tl onComplete!`)
})

tl.seek(0, true, false) 
tl.seek(1, true, false) 
```

## Timeline suppressEvents & suppressTlEvents

`Timeline.seek()` method takes two new arguments: `suppressEvents` & `suppressTlEvents`

````ts
  public seek(progress: number, suppressEvents = true, suppressTlEvents = true): void
````

- only execute the timeline event callbacks:

```ts
tl.seek(0.5, true, false)
```

- only execute "Timeline adds" `onComplete` callbacks : 

```ts
tl.seek(0.5, false, true)
```

`suppressEvents` params as been copied from gsap API. On the other hand, `suppressTlEvents` doesn't exist in GSAP.


## Interpol suppressEvents

In the same way, Interpol `suppressEvents` is available (default: true)

````ts
  public seek(progress: number, suppressEvents = true): void
````

## Callback executions logic

- in Interpol and In Timeline, `onComplete` is called only on play and seek(1)
- `onReverseComplete` should be create for the reverse purpose


## TODO in other PRs

- create `onReverseComplete` 
- exec beforeStart() too 

...