### PR TITLE
Rename `beforeStart` to `onStart`

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ interface IInterpolConstruct<K extends keyof Props> {
 
   // Called when interpol is ready to play
   // default: /
-  beforeStart?: (props?: Record<K, number>, time?: number, progress?: number) => void
+  onStart?: (props?: Record<K, number>, time?: number, progress?: number) => void
 
   // Called on frame update
   // default: /
@@ -411,8 +411,8 @@ interface IInterpolConstruct<K extends keyof Props> {
   // default: /
   onComplete?: (props?: Record<K, number>, time?: number, progress?: number) => void
 
-  // Execute onUpdate method when the Interpol instance is created, just before "beforeStart"
-  // (equivalent to beforeStart)
+  // Execute onUpdate method when the Interpol instance is created, just before "onStart"
+  // (equivalent to onStart)
   // default: false
   initUpdate?: boolean
 }

--- a/examples/interpol-menu/src/components/menu/Menu.tsx
+++ b/examples/interpol-menu/src/components/menu/Menu.tsx
@@ -21,7 +21,7 @@ export function Menu({ isOpen }: { isOpen: boolean }) {
       },
 
       // Use the styles function to update the DOM element
-      beforeStart: ({ x, opacity }) => {
+      onStart: ({ x, opacity }) => {
         styles(rootRef.current, { x, opacity })
       },
 
@@ -44,8 +44,8 @@ export function Menu({ isOpen }: { isOpen: boolean }) {
             y: [100, 0],
             opacity: [0, 1],
           },
-          // Equivalent to copy the onUpdate function on beforeStart
-          // "initUpdate" allows to execute "onUpdate" callback just before "beforeStart"
+          // Equivalent to copy the onUpdate function on onStart
+          // "initUpdate" allows to execute "onUpdate" callback just before "onStart"
           // Useful in this case, onUpdate will be called once, if the timeline is paused
           // in order to give a position to DOM element
           initUpdate: true,

--- a/packages/interpol/CHANGELOG.md
+++ b/packages/interpol/CHANGELOG.md
@@ -143,7 +143,7 @@
   ## TODO in other PRs
 
   - create `onReverseComplete`
-  - exec beforeStart() too
+  - exec onStart() too
 
 ## 0.10.3
 
@@ -376,13 +376,13 @@
 
 ### Minor Changes
 
-- 1d38bab: Improve beforeStart callback:
+- 1d38bab: Improve onStart callback:
 
-  - `beforeStart` get same params than `onUpdate` and `onComplete`:
+  - `onStart` get same params than `onUpdate` and `onComplete`:
     ```ts
-       beforeStart?: (props?: Record<K, number>, time?: number, progress?: number) => void
+       onStart?: (props?: Record<K, number>, time?: number, progress?: number) => void
     ```
-  - A new properties `initUpdate` (boolean) as been added on as Interpol instance property. It allows to execute "onUpdate" callback just before `beforeStart`. Useful in this case, onUpdate will be called once, if the timeline is paused in order to give a position to DOM element.
+  - A new properties `initUpdate` (boolean) as been added on as Interpol instance property. It allows to execute "onUpdate" callback just before `onStart`. Useful in this case, onUpdate will be called once, if the timeline is paused in order to give a position to DOM element.
 
   New "Menu" example:
 

--- a/packages/interpol/README.md
+++ b/packages/interpol/README.md
@@ -147,7 +147,7 @@ interface IInterpolConstruct {
 
   // Called before start
   // default: /
-  beforeStart?: () => void
+  onStart?: () => void
 
   // Called on frame update
   // default: /

--- a/packages/interpol/src/Interpol.ts
+++ b/packages/interpol/src/Interpol.ts
@@ -61,7 +61,7 @@ export class Interpol<K extends keyof Props = keyof Props> {
   #delay: number
   #ease: Ease
   #reverseEase: Ease
-  #beforeStart: CallBack<K>
+  #onStart: CallBack<K>
   #onUpdate: CallBack<K>
   #onComplete: CallBack<K>
   #timeout: ReturnType<typeof setTimeout>
@@ -77,7 +77,7 @@ export class Interpol<K extends keyof Props = keyof Props> {
     paused = false,
     delay = 0,
     initUpdate = false,
-    beforeStart = noop,
+    onStart = noop,
     onUpdate = noop,
     onComplete = noop,
     debug = false,
@@ -88,7 +88,7 @@ export class Interpol<K extends keyof Props = keyof Props> {
     this.#isPaused = paused
     this.#delay = delay
     this.#initUpdate = initUpdate
-    this.#beforeStart = beforeStart
+    this.#onStart = onStart
     this.#el = el
     this.#onUpdate = (props, time, progress) => {
       styles(this.#el, props)
@@ -109,7 +109,7 @@ export class Interpol<K extends keyof Props = keyof Props> {
 
     // start
     if (this.#initUpdate) this.#onUpdate(this.#propsValueRef, this.#time, this.#progress)
-    this.#beforeStart(this.#propsValueRef, this.#time, this.#progress)
+    this.#onStart(this.#propsValueRef, this.#time, this.#progress)
 
     if (!this.#isPaused) this.play()
   }

--- a/packages/interpol/src/core/types.ts
+++ b/packages/interpol/src/core/types.ts
@@ -55,7 +55,7 @@ export interface InterpolConstruct<K extends keyof Props> {
   initUpdate?: boolean
   delay?: number
   debug?: boolean
-  beforeStart?: CallBack<K>
+  onStart?: CallBack<K>
   onUpdate?: CallBack<K>
   onComplete?: CallBack<K>
   el?: El

--- a/packages/interpol/tests/Interpol.callbacks.test.ts
+++ b/packages/interpol/tests/Interpol.callbacks.test.ts
@@ -3,19 +3,19 @@ import { Interpol } from "../src"
 import "./_setup"
 
 describe.concurrent("Interpol callbacks", () => {
-  it("should execute beforeStart before the play", async () => {
+  it("should execute onStart before the play", async () => {
     const pms = (paused: boolean) =>
       new Promise(async (resolve: any) => {
-        const beforeStart = vi.fn()
+        const onStart = vi.fn()
         const itp = new Interpol({
           props: { x: [0, 100] },
           duration: 500,
           paused,
-          beforeStart,
+          onStart,
         })
-        expect(beforeStart).toHaveBeenCalledTimes(1)
+        expect(onStart).toHaveBeenCalledTimes(1)
         await itp.play()
-        expect(beforeStart).toHaveBeenCalledTimes(1)
+        expect(onStart).toHaveBeenCalledTimes(1)
         resolve()
       })
 
@@ -40,7 +40,7 @@ describe.concurrent("Interpol callbacks", () => {
     })
   })
 
-  it("Call onUpdate once on beforeStart if initUpdate is true", () => {
+  it("Call onUpdate once on onStart if initUpdate is true", () => {
     const test = (initUpdate: boolean) =>
       new Promise(async (resolve: any) => {
         const onUpdate = vi.fn()

--- a/packages/interpol/tests/Interpol.el.test.ts
+++ b/packages/interpol/tests/Interpol.el.test.ts
@@ -25,8 +25,8 @@ describe.concurrent("Interpol DOM el", () => {
         duration: 100,
         // init update callback before start
         initUpdate: true,
-        // so beforeStart opacity is already set on div
-        beforeStart: callback,
+        // so onStart opacity is already set on div
+        onStart: callback,
         onUpdate: callback,
         onComplete: callback,
       })
@@ -49,7 +49,7 @@ describe.concurrent("Interpol DOM el", () => {
           props: {
             value: [program.uniform.uProgress.value, 100],
           },
-          beforeStart: callback,
+          onStart: callback,
           onUpdate: callback,
           onComplete: callback,
         })
@@ -70,7 +70,7 @@ describe.concurrent("Interpol DOM el", () => {
           props: {
             v: [program.v, 1000],
           },
-          beforeStart: callback,
+          onStart: callback,
           onUpdate: callback,
           onComplete: callback,
         })

--- a/packages/interpol/tests/Interpol.units.test.ts
+++ b/packages/interpol/tests/Interpol.units.test.ts
@@ -14,7 +14,7 @@ describe.concurrent("Interpol units", () => {
         new Interpol({
           props: { v: [5, 100, unit] },
           duration: 100,
-          beforeStart: ({ v }) => {
+          onStart: ({ v }) => {
             callback({ v })
             expect(v).toBe(5 + unit)
           },
@@ -38,7 +38,7 @@ describe.concurrent("Interpol units", () => {
       new Interpol({
         props: { v: [5, 100] },
         duration: 100,
-        beforeStart: callback,
+        onStart: callback,
         onUpdate: callback,
         onComplete: resolve,
       })

--- a/packages/interpol/tests/Timeline.callbacks.test.ts
+++ b/packages/interpol/tests/Timeline.callbacks.test.ts
@@ -46,7 +46,7 @@ describe.concurrent("Timeline callbacks", () => {
     })
   })
 
-  it("Call onUpdate once on beforeStart if initUpdate is true", () => {
+  it("Call onUpdate once on onStart if initUpdate is true", () => {
     return new Promise(async (resolve: any) => {
       const onUpdate = vi.fn()
       const onUpdate2 = vi.fn()


### PR DESCRIPTION
Rename `beforeStart` method to `onStart` on Interpol instance, in order to more feat to the GSAP's API.

## edit 

- `beforeStart` and `onStart` should be exist both