### PR TITLE
feat: Improve ticker by adding ranking & sort in add() method

### DIFF
--- a/.changeset/new-ladybugs-sniff.md
+++ b/.changeset/new-ladybugs-sniff.md
@@ -1,0 +1,41 @@
+---
+"@wbe/interpol": minor
+---
+
+Use the initial Interpol ticker instance for all raf callback of the application.
+
+A new second param `rank: number` is added to `add()` method. It allows to choose in each order, the callback handker need to be executed. In this exemple, this one is second position, because Interpol ranking is 0
+
+```ts
+import { InterpolOptions } from "@wbe/interpol"
+
+const tickHandler = (t) => console.log(t)
+const rank = 1
+InterpolOptions.ticker.add(tickHandler, rank)
+// ...
+InterpolOptions.ticker.remove(tick)
+```
+
+Using a new ticker instance for all the application:
+
+```ts
+import { Ticker, InterpolOptions } from "@wbe/interpol"
+
+// disable the default Interpol ticker
+InterpolOptions.disable()
+
+// create a new ticker instance
+const ticker = new Ticker()
+
+// Add manually the raf method to the callback list of the new ticker
+const interpolTick = (t) => {
+  InterpolOptions.ticker.raf(e)
+}
+ticker.add(interpolTick, 0)
+
+// Add a new callback to this same ticker instance on rank '1'
+const scrollerTick = (t) => {
+  // ....
+}
+ticker.add(scrollerTick, 1)
+```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ on... anything, for ~=3kB!
 
 ## Summary
 
-- [Playground](#playground-%EF%B8%8F)
+- [Summary](#summary)
+- [Playground 🕹️](#playground-️)
 - [Install](#install)
 - [Basic usage](#basic-usage)
   - [Interpol](#interpol)
@@ -26,16 +27,18 @@ on... anything, for ~=3kB!
 - [Interpol DOM styles](#interpol-dom-styles)
   - [Props unit](#props-unit)
   - [Styles helper](#styles-helper)
-  - [El property](#el-property)
-  - [Real word example](#real-word-example)
+  - [`el` property](#el-property)
+- [Real word example](#real-word-example)
 - [Easing](#easing)
 - [API](#api)
-  - [Interpol constructor](#interpol-constructor)
+  - [interpol constructor](#interpol-constructor)
   - [Interpol methods](#interpol-methods)
   - [Timeline constructor](#timeline-constructor)
   - [Timeline methods](#timeline-methods)
 - [Options](#options)
-  - [Raf](#raf)
+  - [Ticker](#ticker)
+    - [Disable internal raf](#disable-internal-raf)
+    - [Use the internal Ticker instance globally](#use-the-internal-ticker-instance-globally)
   - [Defaults properties](#defaults-properties)
 - [Dev examples](#dev-examples)
 - [Credits](#credits)
@@ -416,12 +419,7 @@ interface IInterpolConstruct<K extends keyof Props> {
 
   // Called on frame update
   // default: /
-  onUpdate?: (
-    props: Record<K, number>,
-    time: number,
-    progress: number,
-    instance: Interpol,
-  ) => void
+  onUpdate?: (props: Record<K, number>, time: number, progress: number, instance: Interpol) => void
 
   // Called when interpol is complete
   // default: /
@@ -544,7 +542,11 @@ tl.seek(progress)
 
 Global option Object is available to set property for each Interpol & Timeline instance.
 
-### Raf
+### Ticker
+
+#### Disable internal raf
+
+It's possible to disable the internal raf and use your own raf callback if needed.
 
 ```ts
 import { InterpolOptions } from "@wbe/interpol"
@@ -557,6 +559,21 @@ const tick = (e) => {
   requestAnimationFrame(tick)
 }
 requestAnimationFrame(tick)
+```
+
+#### Use the internal Ticker instance globally
+
+The internal Ticker instance is available for a global application use. You can add your own raf callback to the Ticker instance and choose the rank of the callback handler.
+
+```ts
+import { InterpolOptions } from "@wbe/interpol"
+
+// Set a new raf callback to the Ticker instance
+const tickHandler = (t) => console.log(t)
+const rank = 1
+InterpolOptions.ticker.add(tickHandler, rank)
+// ...
+InterpolOptions.ticker.remove(tick)
 ```
 
 ### Defaults properties

--- a/packages/interpol/src/core/Ticker.ts
+++ b/packages/interpol/src/core/Ticker.ts
@@ -13,7 +13,7 @@ type Handler = (e: TickParams) => void
  */
 export class Ticker {
   #isRunning = false
-  #handlers: ((e: TickParams) => void)[]
+  #handlers: { handler: (e: TickParams) => void; rank: number }[]
   #onUpdateObj: TickParams
   #start: number
   #time: number
@@ -39,12 +39,14 @@ export class Ticker {
     this.#enable = false
   }
 
-  public add(fn: Handler): void {
-    this.#handlers.push(fn)
+  public add(handler: (e: TickParams) => void, rank: number = 0): () => void {
+    this.#handlers.push({ handler, rank })
+    this.#handlers.sort((a, b) => a.rank - b.rank)
+    return () => this.remove(handler)
   }
 
-  public remove(fn: Handler): void {
-    this.#handlers = this.#handlers.filter((h) => h !== fn)
+  public remove(handler: (e: TickParams) => void): void {
+    this.#handlers = this.#handlers.filter((obj) => obj.handler !== handler)
   }
 
   public play(): void {
@@ -81,7 +83,7 @@ export class Ticker {
     this.#onUpdateObj.delta = this.#delta
     this.#onUpdateObj.time = this.#time
     this.#onUpdateObj.elapsed = this.#elapsed
-    for (const h of this.#handlers) h(this.#onUpdateObj)
+    for (const { handler } of this.#handlers) handler(this.#onUpdateObj)
   }
 
   #initEvents(): void {

--- a/packages/interpol/src/core/Ticker.ts
+++ b/packages/interpol/src/core/Ticker.ts
@@ -13,7 +13,7 @@ type Handler = (e: TickParams) => void
  */
 export class Ticker {
   #isRunning = false
-  #handlers: { handler: (e: TickParams) => void; rank: number }[]
+  #handlers: { handler: Handler; rank: number }[]
   #onUpdateObj: TickParams
   #start: number
   #time: number
@@ -39,13 +39,13 @@ export class Ticker {
     this.#enable = false
   }
 
-  public add(handler: (e: TickParams) => void, rank: number = 0): () => void {
+  public add(handler: Handler, rank: number = 0): () => void {
     this.#handlers.push({ handler, rank })
     this.#handlers.sort((a, b) => a.rank - b.rank)
     return () => this.remove(handler)
   }
 
-  public remove(handler: (e: TickParams) => void): void {
+  public remove(handler: Handler): void {
     this.#handlers = this.#handlers.filter((obj) => obj.handler !== handler)
   }
 


### PR DESCRIPTION
Use the initial Interpol ticker instance for all raf callback of the application.
A new second param `rank: number` is added to `add()` method. It allows to choose in each order, the callback handker need to be executed. In this exemple, this one is second position, because Interpol ranking is 0

```ts
import { InterpolOptions } from "@wbe/interpol"

const tickHandler = (t) => console.log(t)
const rank = 1
InterpolOptions.ticker.add(tickHandler, rank)
// ...
InterpolOptions.ticker.remove(tick)
```

Using a new ticker instance for all the application: 

```ts
import { Ticker, InterpolOptions } from "@wbe/interpol"

// disable the default Interpol ticker 
InterpolOptions.disable()

// create a new ticker instance
const ticker = new Ticker()

// Add manually the raf method to the callback list of the new ticker
const interpolTick = (t) => {
  InterpolOptions.ticker.raf(e)
}
ticker.add(interpolTick, 0)

// Add a new callback to this same ticker instance on rank '1'
const scrollerTick = (t) => {
  // ....
}
ticker.add(scrollerTick, 1)

```