### PR TITLE
feat: Add duration factor option

### DIFF
--- a/.changeset/heavy-doors-hang.md
+++ b/.changeset/heavy-doors-hang.md
@@ -1,0 +1,19 @@
+---
+"@wbe/interpol": minor
+---
+
+Set a new the global `durationFactor` for each Interpol instances.
+It makes the Interpol usage more closer to gsap, if needed:
+
+```ts
+import { Interpol, InterpolOptions } from "@wbe/interpol"
+
+// set a new global durationFactor
+InterpolOptions.durationFactor = 1000 // second
+new Interpol({
+  duration: 1, // 1 = one second
+  onComplete: (_, time) => {
+    console.log(time) // 1000
+  },
+})
+```

--- a/README.md
+++ b/README.md
@@ -567,8 +567,10 @@ InterpolOptions.ticker.remove(tick)
 
 ```ts
 import { InterpolOptions } from "@wbe/interpol"
+// Set default duration factor for all interpol instances, 1 is millisecond / 1000 is second
+InterpolOptions.durationFacror = 1
 // Set default duration for all interpol instances
-InterpolOptions.durarion = 1000
+InterpolOptions.duration = 1000
 // Set default easing for all interpol instances
 InterpolOptions.ease = (t) => t * t
 ```

--- a/packages/interpol/src/Interpol.ts
+++ b/packages/interpol/src/Interpol.ts
@@ -117,7 +117,7 @@ export class Interpol<K extends keyof Props = keyof Props> {
 
   // Compute if values were functions
   public refreshComputedValues(): void {
-    this.#_duration = compute(this.#duration)
+    this.#_duration = compute(this.#duration) * InterpolOptions.durationFactor
     this.#onEachProps((prop) => {
       prop._from = compute(prop.from)
       prop._to = compute(prop.to)

--- a/packages/interpol/src/options.ts
+++ b/packages/interpol/src/options.ts
@@ -7,12 +7,14 @@ import { Ease } from "./core/ease"
  */
 interface InterpolOptions {
   ticker: Ticker
+  durationFactor: number
   duration: Value
   ease: Ease
 }
 
 export const InterpolOptions: InterpolOptions = {
   ticker: new Ticker(),
+  durationFactor: 1,
   duration: 1000,
   ease: "linear",
 }

--- a/packages/interpol/tests/Interpol.duration.test.ts
+++ b/packages/interpol/tests/Interpol.duration.test.ts
@@ -18,6 +18,17 @@ describe.concurrent("Interpol duration", () => {
     }).play()
   })
 
+  it("should use duration in second for global interpol instances", async () => {
+    // use the default durationFactor (1)
+    InterpolOptions.durationFactor = 1000
+    InterpolOptions.duration = 0.2
+    return new Interpol({
+      onComplete: (_, time) => {
+        expect(time).toBe(200)
+      },
+    }).play()
+  })
+
   it("should accept custom durationFactor", async () => {
     const test = (durationFactor: number, duration: Value) => {
       // set the custom durationFactor
@@ -29,15 +40,14 @@ describe.concurrent("Interpol duration", () => {
             (typeof duration === "function" ? duration() : duration) * durationFactor,
           )
         },
-      })
+      }).play()
     }
 
+    // prettier-ignore
     return Promise.all([
+      test(0.5, 400),
       test(1, 200),
-      test(1000, 100),
-      test(0.5, 200),
-      test(0.5, () => 200),
-      test(10000, () => 300),
+      test(1000, 0.2),    
     ])
   })
 })

--- a/packages/interpol/tests/Interpol.duration.test.ts
+++ b/packages/interpol/tests/Interpol.duration.test.ts
@@ -1,0 +1,43 @@
+import { it, expect, describe, afterEach } from "vitest"
+import { Interpol, InterpolOptions } from "../src"
+import "./_setup"
+import { Value } from "../src/core/types"
+
+describe.concurrent("Interpol duration", () => {
+  afterEach(() => {
+    InterpolOptions.durationFactor = 1
+  })
+
+  it("should have 1 as durationFactor by default", async () => {
+    // use the default durationFactor (1)
+    return new Interpol({
+      duration: 200,
+      onComplete: (_, time) => {
+        expect(time).toBe(200)
+      },
+    }).play()
+  })
+
+  it("should accept custom durationFactor", async () => {
+    const test = (durationFactor: number, duration: Value) => {
+      // set the custom durationFactor
+      InterpolOptions.durationFactor = durationFactor
+      return new Interpol({
+        duration,
+        onComplete: (_, time) => {
+          expect(time).toBe(
+            (typeof duration === "function" ? duration() : duration) * durationFactor,
+          )
+        },
+      })
+    }
+
+    return Promise.all([
+      test(1, 200),
+      test(1000, 100),
+      test(0.5, 200),
+      test(0.5, () => 200),
+      test(10000, () => 300),
+    ])
+  })
+})


### PR DESCRIPTION
Set a new the global `durationFactor` for each Interpol instances. 
It makes the Interpol usage more closer to gsap, if needed:

```ts
import { Interpol, InterpolOptions } from "@wbe/interpol"

// set a new global durationFactor
InterpolOptions.durationFactor = 1000 // second
new Interpol({
      duration: 1, // 1 = one second
      onComplete: (_, time) => {
        console.log(time) // 1000 
      },
    })
```