### PR TITLE
fix: Interpol & Timeline reverse Promise

### DIFF
--- a/.changeset/clever-starfishes-suffer.md
+++ b/.changeset/clever-starfishes-suffer.md
@@ -1,0 +1,32 @@
+---
+"@wbe/interpol": patch
+---
+
+fix: Interpol & Timeline reverse Promise
+
+`play` and `reverse` before the end of the `play`. The reverse promise was non-existent.
+The expected behavior is to get a a reverse promise who resolve when the `reserve()` is complete.
+
+before:
+
+```ts
+const duration = 1000
+const itp = new Interpol({ duration })
+
+itp.play()
+await new Promise((r) => setTimeout(r, duration / 2))
+await itp.reverse()
+console.log("reverse complete") // bug: was called before the reverse end
+```
+
+after:
+
+```ts
+const duration = 1000
+const itp = new Interpol({ duration })
+
+itp.play()
+await new Promise((r) => setTimeout(r, duration / 2))
+await itp.reverse()
+console.log("reverse complete") // is called when reverse is complete
+```

--- a/packages/interpol/src/Interpol.ts
+++ b/packages/interpol/src/Interpol.ts
@@ -150,10 +150,11 @@ export class Interpol<K extends string = string> {
 
   public async reverse(from: number = 1, allowReplay = true): Promise<any> {
     if (this.#isPlaying && !allowReplay) return
-    // If is playing normal direction, change to reverse and return
+    // If is playing normal direction, change to reverse and return a new promise
     if (this.#isPlaying && !this.#isReversed) {
       this.#isReversed = true
-      return
+      this.#onCompleteDeferred = deferredPromise()
+      return this.#onCompleteDeferred.promise
     }
     // If is playing reverse, restart reverse
     if (this.#isPlaying && this.#isReversed) {

--- a/packages/interpol/src/Timeline.ts
+++ b/packages/interpol/src/Timeline.ts
@@ -169,7 +169,8 @@ export class Timeline {
     // If TL is playing in normal direction, change to reverse and return
     if (this.#isPlaying && !this.#isReversed) {
       this.#isReversed = true
-      return
+      this.#onCompleteDeferred = deferredPromise()
+      return this.#onCompleteDeferred.promise
     }
     // If is playing reverse, restart reverse
     if (this.#isPlaying && this.#isReversed) {

--- a/packages/interpol/src/Timeline.ts
+++ b/packages/interpol/src/Timeline.ts
@@ -166,7 +166,7 @@ export class Timeline {
 
   public async reverse(from: number = 1): Promise<any> {
     this.#reverseFrom = from
-    // If TL is playing in normal direction, change to reverse and return
+    // If TL is playing in normal direction, change to reverse and return a new promise
     if (this.#isPlaying && !this.#isReversed) {
       this.#isReversed = true
       this.#onCompleteDeferred = deferredPromise()

--- a/packages/interpol/tests/Interpol.reverse.test.ts
+++ b/packages/interpol/tests/Interpol.reverse.test.ts
@@ -4,23 +4,72 @@ import { wait } from "./utils/wait"
 import "./_setup"
 
 describe.concurrent("Interpol reverse", () => {
-  it("should reverse the interpolation", async () => {
-    const onComplete = vi.fn()
-    const onUpdate = vi.fn()
+  it("should update 'isRevered' state", async () => {
     return new Promise(async (resolve: any) => {
+      const duration = 500
       const itp = new Interpol({
-        v: [0, 10],
-        duration: 1000,
-        onUpdate,
-        onComplete,
+        paused: true,
+        duration,
       })
       expect(itp.isReversed).toBe(false)
       await wait(100)
       itp.reverse()
       expect(itp.isReversed).toBe(true)
-      await wait(1000)
+      resolve()
+    })
+  })
+
+  it("should not call onComplete if play is not resolved", async () => {
+    const onComplete = vi.fn()
+    return new Promise(async (resolve: any) => {
+      const duration = 300
+      const itp = new Interpol({
+        paused: true,
+        duration,
+        onComplete,
+      })
+
+      itp.play()
+      await wait(duration / 2)
+      itp.reverse()
+      await wait(duration)
       expect(onComplete).toHaveBeenCalledTimes(0)
       resolve()
     })
+  })
+
+  it("should resolve reverse() promise when reverse is complete", async () => {
+    const test = async ({ duration, waitBetweenPlayAndReverse }) => {
+      const reverseComplete = vi.fn()
+      const itp = new Interpol({ duration, paused: true })
+      // play and wait half duration
+      itp.play()
+      await wait(waitBetweenPlayAndReverse)
+      // reverse during the play
+      await itp.reverse().then(() => reverseComplete())
+      // the reverse() promise should resolve when the reverse is complete
+      expect(reverseComplete).toHaveBeenCalledTimes(1)
+    }
+
+    return Promise.all([
+      // wait long time between play and reverse
+      test({
+        duration: 100,
+        waitBetweenPlayAndReverse: 100 * 2,
+      }),
+
+      // wait only the duration of the play before reverse
+      test({
+        duration: 100,
+        waitBetweenPlayAndReverse: 100,
+      }),
+
+      // wait half the duration of the play before reverse
+      // Start the reverse during the play
+      test({
+        duration: 100,
+        waitBetweenPlayAndReverse: 100 / 2,
+      }),
+    ])
   })
 })

--- a/packages/interpol/tests/Timeline.reverse.test.ts
+++ b/packages/interpol/tests/Timeline.reverse.test.ts
@@ -1,12 +1,14 @@
 import { it, expect, vi, describe } from "vitest"
 import { Timeline } from "../src"
 import "./_setup"
+import { wait } from "./utils/wait"
 
 describe.concurrent("Timeline reverse", () => {
   it("should reverse timeline properly", () => {
     const timeMock = vi.fn(() => 0)
     const progressMock = vi.fn(() => 0)
     const onCompleteMock = vi.fn()
+    const reverseCompleteMock = vi.fn()
 
     return new Promise(async (resolve: any) => {
       const tl = new Timeline({
@@ -34,8 +36,16 @@ describe.concurrent("Timeline reverse", () => {
       await tl.play()
       await tl.reverse()
       await tl.play()
-      await tl.reverse()
+      tl.reverse().then(() => {
+        reverseCompleteMock()
+      })
+      // reverse is not complete yet
+      expect(reverseCompleteMock).toBeCalledTimes(0)
+      await wait(300)
+      // reverse is complete
+      expect(reverseCompleteMock).toBeCalledTimes(1)
 
+      // onComplete is called 2 times
       expect(onCompleteMock).toBeCalledTimes(2)
       resolve()
     })


### PR DESCRIPTION
`play` and `reverse` before the end of the `play`. The reverse promise was non-existent.
The expected behavior is to get a a reverse promise who resolve when the `reserve()` is complete.

before:

```ts
const duration = 1000
const itp = new Interpol({ duration })

itp.play()
await new Promise((r) => setTimeout(r, duration / 2))
await itp.reverse()
console.log("reverse complete") // bug: was called before the reverse end
```

after:

```ts
const duration = 1000
const itp = new Interpol({ duration })

itp.play()
await new Promise((r) => setTimeout(r, duration / 2))
await itp.reverse()
console.log("reverse complete") // is called when reverse is complete
```
