### PR TITLE
api: Rename refreshComputedValues() to refresh()

### DIFF
--- a/.changeset/dirty-numbers-argue.md
+++ b/.changeset/dirty-numbers-argue.md
@@ -1,0 +1,27 @@
+---
+"@wbe/interpol": minor
+---
+
+Rename `refreshComputedValues()` to `refresh()`
+
+`refreshComputedValues()` is deprecated. Use `refresh()` instead.
+
+before:
+
+```ts
+const itp = new Interpol({ ... })
+itp.refreshComputedValues()
+
+const tl = new Timeline({ ... })
+tl.refreshComputedValues()
+```
+
+after:
+
+```ts
+const itp = new Interpol({ ... })
+itp.refresh()
+
+const tl = new Timeline({ ... })
+tl.refresh()
+```

--- a/README.md
+++ b/README.md
@@ -198,13 +198,13 @@ new Interpol({
 })
 ```
 
-In order to refresh computed values, you can use the `refreshComputedValues` method:
+In order to refresh computed values, you can use the `refresh` method:
 
 ```ts
 const itp = new Interpol({
   // ...
 })
-itp.refreshComputedValues()
+itp.refresh()
 ```
 
 ## Styles helper
@@ -380,8 +380,8 @@ itp.resume()
 itp.stop()
 
 // Compute 'from', 'to' and 'duration' values if there are functions
-// refreshComputedValues(): void
-itp.refreshComputedValues()
+// refresh(): void
+itp.refresh()
 
 // Set progress to a specific value
 // progress(value: number, suppressEvents = true): void
@@ -450,7 +450,7 @@ tl.resume()
 tl.stop()
 
 // compute 'from', 'to' and 'duration' values on each adds if there are functions
-tl.refreshComputedValues()
+tl.refresh()
 
 // set progress to a specific value
 // value is a number between 0 and 1

--- a/README.md
+++ b/README.md
@@ -302,11 +302,11 @@ interface IInterpolConstruct<K extends keyof Props> {
 
   // Interpol easing function
   // default: `t => t` (lineal easing)
-  ease?: EaseName | EaseFn
+  ease?: (EaseName | EaseFn) | (() => EaseName | EaseFn)
 
   // Overwrite easing function on reverse
-  // default: /
-  reverseEase?: EaseName | EaseFn
+  // default: `ease`
+  reverseEase?: (EaseName | EaseFn) | (() => EaseName | EaseFn)
 
   // Make interpol paused at start (not autoplay)
   // default: `false`
@@ -314,7 +314,7 @@ interface IInterpolConstruct<K extends keyof Props> {
 
   // Add delay before first start
   // default: `false`
-  delay?: number
+  delay?: number | (() => number)
 
   // Enable debug to get interpol logs information
   // default: `false`
@@ -379,7 +379,7 @@ itp.resume()
 // stop(): void
 itp.stop()
 
-// Compute 'from', 'to' and 'duration' values if there are functions
+// Compute 'from', 'to' 'duration', 'ease' & 'delay' values if there are functions
 // refresh(): void
 itp.refresh()
 
@@ -449,7 +449,7 @@ tl.resume()
 // stop(): void
 tl.stop()
 
-// compute 'from', 'to' and 'duration' values on each adds if there are functions
+// call refresh on each interpol instance
 tl.refresh()
 
 // set progress to a specific value

--- a/examples/interpol-basic/src/main.ts
+++ b/examples/interpol-basic/src/main.ts
@@ -27,18 +27,18 @@ pane.addButton({ title: "reverse" }).on("click", () => itp.reverse())
 pane.addButton({ title: "pause" }).on("click", () => itp.pause())
 pane.addButton({ title: "stop" }).on("click", () => itp.stop())
 pane.addButton({ title: "resume" }).on("click", () => itp.resume())
-pane.addButton({ title: "refresh" }).on("click", () => itp.refreshComputedValues())
+pane.addButton({ title: "refresh" }).on("click", () => itp.refresh())
 
 // add x binding
 pane.addBinding(PARAMS, "x", { min: -200, max: 200, label: "x (to)" }).on("change", () => {
-  itp.refreshComputedValues()
+  itp.refresh()
 })
 
 // add scale binding
 pane
   .addBinding(PARAMS, "scale", { min: 0.7, max: 2.5, step: 0.1, label: "scale (to)" })
   .on("change", () => {
-    itp.refreshComputedValues()
+    itp.refresh()
   })
 
 pane.addBinding({ progress: itp.progress() }, "progress", { min: 0, max: 1 }).on("change", (ev) => {
@@ -46,7 +46,7 @@ pane.addBinding({ progress: itp.progress() }, "progress", { min: 0, max: 1 }).on
 })
 
 pane.addBinding(PARAMS, "duration", { min: 0, max: 10000, step: 100 }).on("change", () => {
-  itp.refreshComputedValues()
+  itp.refresh()
 })
 
 const eases = [
@@ -76,5 +76,5 @@ pane
     options: eases,
   })
   .on("change", () => {
-    itp.refreshComputedValues()
+    itp.refresh()
   })

--- a/examples/interpol-delay/src/main.ts
+++ b/examples/interpol-delay/src/main.ts
@@ -25,7 +25,7 @@ for (let i = 0; i < 120; i++) {
 
   const yoyo = async () => {
     await itp.play()
-    itp.refreshComputedValues()
+    itp.refresh()
     yoyo()
   }
   yoyo()

--- a/examples/interpol-grid/src/main.ts
+++ b/examples/interpol-grid/src/main.ts
@@ -59,7 +59,7 @@ for (let i = 0; i < num; i++) {
 
   el.addEventListener("mousemove", async () => {
     if (itp.isPlaying) return
-    itp.refreshComputedValues()
+    itp.refresh()
     await itp.play()
     await itp.reverse()
   })

--- a/examples/interpol-particles/src/main.tsx
+++ b/examples/interpol-particles/src/main.tsx
@@ -54,7 +54,7 @@ export function App() {
       })
       itps.push(itp)
       const yoyo = () => {
-        itp.refreshComputedValues()
+        itp.refresh()
         itp.play().then(() => itp.reverse().then(yoyo))
       }
       yoyo()

--- a/examples/interpol-progress-reset-wall/src/main.ts
+++ b/examples/interpol-progress-reset-wall/src/main.ts
@@ -37,7 +37,7 @@ const testWithInterpol = () => {
   })
 
   window.addEventListener("resize", () => {
-    itp.refreshComputedValues()
+    itp.refresh()
     itp.progress(0)
     isVisible = false
   })
@@ -82,7 +82,7 @@ const testWithTimeline = () => {
     openClose()
   })
   window.addEventListener("resize", () => {
-    tl.refreshComputedValues()
+    tl.refresh()
     tl.progress(0)
     isVisible = false
   })

--- a/packages/interpol/README.md
+++ b/packages/interpol/README.md
@@ -198,13 +198,13 @@ new Interpol({
 })
 ```
 
-In order to refresh computed values, you can use the `refreshComputedValues` method:
+In order to refresh computed values, you can use the `refresh` method:
 
 ```ts
 const itp = new Interpol({
   // ...
 })
-itp.refreshComputedValues()
+itp.refresh()
 ```
 
 ## Styles helper
@@ -380,8 +380,8 @@ itp.resume()
 itp.stop()
 
 // Compute 'from', 'to' and 'duration' values if there are functions
-// refreshComputedValues(): void
-itp.refreshComputedValues()
+// refresh(): void
+itp.refresh()
 
 // Set progress to a specific value
 // progress(value: number, suppressEvents = true): void
@@ -450,7 +450,7 @@ tl.resume()
 tl.stop()
 
 // compute 'from', 'to' and 'duration' values on each adds if there are functions
-tl.refreshComputedValues()
+tl.refresh()
 
 // set progress to a specific value
 // value is a number between 0 and 1

--- a/packages/interpol/src/Interpol.ts
+++ b/packages/interpol/src/Interpol.ts
@@ -112,7 +112,7 @@ export class Interpol<K extends string = string> {
     // Prepare & compute props
     this.#originalProps = inlineProps
     // Compute all values (duration, delay, ease, props values)
-    this.refreshComputedValues()
+    this.refresh()
     // Create callback props object
     this.#callbackProps = this.#createPropsParamObjRef<K>(this.#props)
     // Initial callbacks
@@ -124,7 +124,7 @@ export class Interpol<K extends string = string> {
   }
 
   // Compute if values were functions
-  public refreshComputedValues(): void {
+  public refresh(): void {
     // re preprare all props
     this.#props = this.#prepareProps<K>(this.#originalProps)
 
@@ -142,6 +142,14 @@ export class Interpol<K extends string = string> {
       prop.ease = prop._computeEaseFn(this.#_ease)
       prop.reverseEase = prop._computeReverseEaseFn(this.#_reverseEase)
     }
+  }
+
+  /**
+   * @deprecated use refresh() instead
+   */
+  public refreshComputedValues(): void {
+    console.warn(`Interpol.refresh() is deprecated. Use Interpol.refresh() instead.`)
+    this.refresh()
   }
 
   public async play(from: number = 0, allowReplay = true): Promise<any> {
@@ -265,7 +273,7 @@ export class Interpol<K extends string = string> {
       (this.#progress !== 0 && this.#lastProgress === 0) ||
       (this.#progress !== 1 && this.#lastProgress === 1)
     ) {
-      this.refreshComputedValues()
+      this.refresh()
     }
 
     // Update time, interpolate and assign props value

--- a/packages/interpol/src/Interpol.ts
+++ b/packages/interpol/src/Interpol.ts
@@ -148,7 +148,7 @@ export class Interpol<K extends string = string> {
    * @deprecated use refresh() instead
    */
   public refreshComputedValues(): void {
-    console.warn(`Interpol.refresh() is deprecated. Use Interpol.refresh() instead.`)
+    console.warn(`Interpol.refreshComputedValues() is deprecated. Use Interpol.refresh() instead.`)
     this.refresh()
   }
 

--- a/packages/interpol/src/Timeline.ts
+++ b/packages/interpol/src/Timeline.ts
@@ -89,7 +89,7 @@ export class Timeline {
     }
     const itp = interpol instanceof Interpol ? interpol : new Interpol<K>(interpol)
     itp.stop()
-    itp.refreshComputedValues()
+    itp.refresh()
     itp.ticker = this.#ticker
     itp.inTl = true
     if (this.#debugEnable) itp.debugEnable = this.#debugEnable
@@ -234,8 +234,16 @@ export class Timeline {
     }
   }
 
+  public refresh(): void {
+    this.#onAllAdds((e) => e.itp.refresh())
+  }
+
+  /**
+   * @deprecated use refresh() instead
+   */
   public refreshComputedValues(): void {
-    this.#onAllAdds((e) => e.itp.refreshComputedValues())
+    console.warn(`Timeline.refreshComputedValues() is deprecated. Use Timeline.refresh() instead.`)
+    this.refresh()
   }
 
   /**

--- a/packages/interpol/tests/Interpol.delay.test.ts
+++ b/packages/interpol/tests/Interpol.delay.test.ts
@@ -90,7 +90,7 @@ describe.concurrent("Interpol delay", () => {
     })
   })
 
-  it('should refesh delay when calling "refreshComputedValues()"', () => {
+  it('should refesh delay when calling "refresh()"', () => {
     return new Promise(async (resolve: any) => {
       InterpolOptions.durationFactor = 1
       InterpolOptions.duration = 1000
@@ -113,7 +113,7 @@ describe.concurrent("Interpol delay", () => {
       })
 
       for (let i = 0; i < 10; i++) {
-        itp.refreshComputedValues()
+        itp.refresh()
         expect(itp.delay).not.toEqual(currDelay)
       }
 

--- a/packages/interpol/tests/Interpol.refresh.test.ts
+++ b/packages/interpol/tests/Interpol.refresh.test.ts
@@ -18,7 +18,7 @@ describe.concurrent("Interpol refresh", () => {
     })
   })
 
-  it("should re compute if refreshComputedValues() is called", async () => {
+  it("should re compute if refresh() is called", async () => {
     return new Promise(async (resolve: any) => {
       const mockTo = vi.fn()
       const mockFrom = vi.fn()
@@ -41,7 +41,7 @@ describe.concurrent("Interpol refresh", () => {
       expect(mockTo).toHaveBeenCalledTimes(1)
       expect(itp.duration).toBe(66)
       await wait(itp.duration)
-      itp.refreshComputedValues()
+      itp.refresh()
       await wait(500)
       expect(mockFrom).toHaveBeenCalledTimes(2)
       expect(mockTo).toHaveBeenCalledTimes(2)

--- a/packages/interpol/tests/Timeline.refresh.test.ts
+++ b/packages/interpol/tests/Timeline.refresh.test.ts
@@ -9,7 +9,7 @@ describe.concurrent("Timeline auto refresh computed values", () => {
      * as "from" of the second add().
      *
      * It will work if "from" of the second add() is a computed value
-     * Behind the scene, we re-execute refreshComputedValues() juste before the add() starts
+     * Behind the scene, we re-execute refresh() juste before the add() starts
      */
     const tl = new Timeline({ paused: true })
     let EXTERNAL_X = 0

--- a/packages/interpol/tests/ease.test.ts
+++ b/packages/interpol/tests/ease.test.ts
@@ -72,7 +72,7 @@ describe.concurrent("Ease", () => {
       // wait after the middle of the tween
       // and refresh
       await wait(200)
-      itp.refreshComputedValues()
+      itp.refresh()
 
       // ease functions should be updated
       expect(itp.ease).toBe(Power1.out)


### PR DESCRIPTION
`refreshComputedValues()` is deprecated. Use `refresh()` instead.

before:

```ts
const itp = new Interpol({ ... })
itp.refreshComputedValues()

const tl = new Timeline({ ... })
tl.refreshComputedValues()
```

after:

```ts
const itp = new Interpol({ ... })
itp.refresh()

const tl = new Timeline({ ... })
tl.refresh()
```
